### PR TITLE
Fixes for Great Groups of Histels v.s. Suborders of Histosols

### DIFF
--- a/R/formative-elements.R
+++ b/R/formative-elements.R
@@ -37,19 +37,31 @@ FormativeElements <- function(x, level = c("order","suborder","greatgroup","subg
   haystack <- lut$element
   pattern <- haystack
   
+  # split into tokens using spaces
+  tok <- strsplit(x, " ", fixed = TRUE)
+  
   if (level == "order") {
     # soil order is always encoded at the end of last word
     pattern <- paste0(haystack, '$')
-    tok <- strsplit(x, " ", fixed=TRUE)  
+
   } else if (level == "greatgroup") {
-    # soil great group is always the last word
-    pattern <- paste0("\\b",haystack)
-    tok <- strsplit(x, " ", fixed=TRUE)
+    # soil great group is preceded by a word boundary
+    pattern <- paste0("\\b", haystack)
+    
   } else {
+    
+    if (level == "suborder") {
+      # Suborder is always followed by a non-"s" character (an order element)
+      #   - this covers the use of *ist* in the suborders of Gelisols
+      #  Great Groups of Histels have formative elements that overlap Suborders of Histosols
+      pattern <- paste0(haystack, '[^s]')  
+    }
+    
     # get the taxonomic name at the specified level (simplifies search/matching)
     res <- getTaxonAtLevel(x, level = level)
-    # split into tokens
-    tok <- strsplit(res, " ", fixed=TRUE)
+    
+    # split into tokens using result
+    tok <- strsplit(res, " ", fixed = TRUE)
   }
   
   tok.len <- sapply(tok, length)

--- a/tests/testthat/test-formative-element-parsing.R
+++ b/tests/testthat/test-formative-element-parsing.R
@@ -164,6 +164,13 @@ test_that("explainST", {
   # explain a formative element position in order name
   expect_output(cat(explainST("aridisols")))
   
+  # explain several challenging suborders and great groups
+  expect_output(cat(explainST("saprists")))
+  expect_output(cat(explainST("sapristels")))
+  
+  expect_output(cat(explainST("folists")))
+  expect_output(cat(explainST("folistels")))
+  
   data("ST_higher_taxa_codes_12th")
   
   subgroups <- ST_higher_taxa_codes_12th[nchar(ST_higher_taxa_codes_12th$code) >= 4,]


### PR DESCRIPTION
These calls have run without error since the expansion of `explainST` to be less picky about non-subgroup input... but the result would often match the "wrong" explanation/formative element where `*ist*` is used as a _suborder_ formative element.

Now these Great Groups of Histels and Suborders of Histosols work as expected.

``` r
library(SoilTaxonomy)

cat(explainST("saprists"))
#> saprists
#> |   |                                                                                               
#> most decomposed stage of organic matter                                                             
#>     |                                                                                               
#>     soils with more than 30% organic matter content to a depth of 40cm or more
cat(explainST("sapristels"))
#> sapristels
#> |   |  |                                                                                            
#> most decomposed stage                                                                               
#>     |  |                                                                                            
#>     presence of organic soil materials                                                              
#>        |                                                                                            
#>        soils with permafrost or gelic material within 100cm

cat(explainST("hemists"))
#> hemists
#> |  |                                                                                                
#> intermediate state of decomposition                                                                 
#>    |                                                                                                
#>    soils with more than 30% organic matter content to a depth of 40cm or more
cat(explainST("hemistels"))
#> hemistels
#> |  |  |                                                                                             
#> intermediate decomposition                                                                          
#>    |  |                                                                                             
#>    presence of organic soil materials                                                               
#>       |                                                                                             
#>       soils with permafrost or gelic material within 100cm

cat(explainST("fibrists"))
#> fibrists
#> |   |                                                                                               
#> least decomposed stage of organic material                                                          
#>     |                                                                                               
#>     soils with more than 30% organic matter content to a depth of 40cm or more
cat(explainST("fibristels"))
#> fibristels
#> |   |  |                                                                                            
#> least decomposed stage                                                                              
#>     |  |                                                                                            
#>     presence of organic soil materials                                                              
#>        |                                                                                            
#>        soils with permafrost or gelic material within 100cm

cat(explainST("folists"))
#> folists
#> |  |                                                                                                
#> mass of leaves                                                                                      
#>    |                                                                                                
#>    soils with more than 30% organic matter content to a depth of 40cm or more
cat(explainST("folistels"))
#> folistels
#> |  |  |                                                                                             
#> mass of leaves                                                                                      
#>    |  |                                                                                             
#>    presence of organic soil materials                                                               
#>       |                                                                                             
#>       soils with permafrost or gelic material within 100cm
```